### PR TITLE
V5.1.26 hf

### DIFF
--- a/coverage-reports/pom.xml
+++ b/coverage-reports/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.siddhi</groupId>
         <artifactId>siddhi</artifactId>
-        <version>5.1.26</version>
+        <version>5.1.26-HF</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/modules/siddhi-annotations/pom.xml
+++ b/modules/siddhi-annotations/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>io.siddhi</groupId>
         <artifactId>siddhi</artifactId>
-        <version>5.1.26</version>
+        <version>5.1.26-HF</version>
         <relativePath>../..</relativePath>
     </parent>
 

--- a/modules/siddhi-core/pom.xml
+++ b/modules/siddhi-core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>siddhi</artifactId>
         <groupId>io.siddhi</groupId>
-        <version>5.1.26</version>
+        <version>5.1.26-HF</version>
         <relativePath>../../pom.xml</relativePath>
 
     </parent>

--- a/modules/siddhi-core/siddhi-core-doc-gen/pom.xml
+++ b/modules/siddhi-core/siddhi-core-doc-gen/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>siddhi</artifactId>
         <groupId>io.siddhi</groupId>
-        <version>5.1.26</version>
+        <version>5.1.26-HF</version>
         <relativePath>../../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/modules/siddhi-core/src/main/java/io/siddhi/core/event/stream/holder/SnapshotableStreamEventQueue.java
+++ b/modules/siddhi-core/src/main/java/io/siddhi/core/event/stream/holder/SnapshotableStreamEventQueue.java
@@ -99,6 +99,9 @@ public class SnapshotableStreamEventQueue implements Iterator<StreamEvent>, Seri
         }
         if (previousToLastReturned != null) {
             previousToLastReturned.setNext(lastReturned.getNext());
+            if (lastReturned.getNext() == null) {
+                last = previousToLastReturned;
+            }
         } else {
             first = lastReturned.getNext();
             if (first == null) {

--- a/modules/siddhi-doc-gen/pom.xml
+++ b/modules/siddhi-doc-gen/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>siddhi</artifactId>
         <groupId>io.siddhi</groupId>
-        <version>5.1.26</version>
+        <version>5.1.26-HF</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/modules/siddhi-feature/pom.xml
+++ b/modules/siddhi-feature/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>siddhi</artifactId>
         <groupId>io.siddhi</groupId>
-        <version>5.1.26</version>
+        <version>5.1.26-HF</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/modules/siddhi-query-api/pom.xml
+++ b/modules/siddhi-query-api/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>siddhi</artifactId>
         <groupId>io.siddhi</groupId>
-        <version>5.1.26</version>
+        <version>5.1.26-HF</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/modules/siddhi-query-compiler/pom.xml
+++ b/modules/siddhi-query-compiler/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>siddhi</artifactId>
         <groupId>io.siddhi</groupId>
-        <version>5.1.26</version>
+        <version>5.1.26-HF</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/modules/siddhi-samples/performance-samples/pom.xml
+++ b/modules/siddhi-samples/performance-samples/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>io.siddhi</groupId>
         <artifactId>siddhi-samples</artifactId>
-        <version>5.1.26</version>
+        <version>5.1.26-HF</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>performance-samples</artifactId>

--- a/modules/siddhi-samples/pom.xml
+++ b/modules/siddhi-samples/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>siddhi</artifactId>
         <groupId>io.siddhi</groupId>
-        <version>5.1.26</version>
+        <version>5.1.26-HF</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/modules/siddhi-samples/quick-start-samples/pom.xml
+++ b/modules/siddhi-samples/quick-start-samples/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>siddhi-samples</artifactId>
         <groupId>io.siddhi</groupId>
-        <version>5.1.26</version>
+        <version>5.1.26-HF</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/modules/siddhi-service/pom.xml
+++ b/modules/siddhi-service/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>siddhi</artifactId>
         <groupId>io.siddhi</groupId>
-        <version>5.1.26</version>
+        <version>5.1.26-HF</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <groupId>io.siddhi</groupId>
     <artifactId>siddhi</artifactId>
     <packaging>pom</packaging>
-    <version>5.1.26</version>
+    <version>5.1.26-HF</version>
     <name>Siddhi</name>
     <description>Siddhi, Stream Processing and Complex Event Processing Engine</description>
 


### PR DESCRIPTION
## Purpose
> Resolves issue [1822](https://github.com/siddhi-io/siddhi/issues/1822) - Removal of the last stored event in the InMemory table disrupts the references chain, subsequently causing improper behaviour within the InMemory table. Any future inserts are erroneously appended to the removed event, leading to unexpected and undesired outcomes.

## Goals
> Fix the logic of the remove method in the SnapshotableStreamEventQueue class to gracefully handle the removal of the last item. Reset the `last` variable to point to the previous item if the item being removed is the last one.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

